### PR TITLE
feat(field-mapping): add cached alias

### DIFF
--- a/projects/civilio/src/app/components/form/field/field.component.html
+++ b/projects/civilio/src/app/components/form/field/field.component.html
@@ -27,7 +27,6 @@
 		<ng-container [ngTemplateOutlet]="numberTemplate" />
 	}
 	@case ("point") {
-		{{ _value() | json }}
 		<ng-container [ngTemplateOutlet]="geoPointTemplate" />
 	}
 	@case ("table") {
@@ -42,7 +41,7 @@
 <ng-template #geoPointTemplate>
 	<ng-container [ngTemplateOutlet]="labelTemplate" />
 	<cv-geo-point
-		[(value)]="_value"
+		[value]="_value()"
 		(touched)="onControlTouched()"
 		(changed)="onInput($event)"
 		[disabled]="_disabled()"

--- a/projects/civilio/src/app/components/form/field/field.component.ts
+++ b/projects/civilio/src/app/components/form/field/field.component.ts
@@ -1,5 +1,5 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { DatePipe, JsonPipe, NgTemplateOutlet } from '@angular/common';
+import { DatePipe, NgTemplateOutlet } from '@angular/common';
 import { booleanAttribute, ChangeDetectionStrategy, ChangeDetectorRef, Component, effect, forwardRef, inject, input, model, output, signal } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { GeoPointComponent } from '@app/components/geo-point/geo-point.component';
@@ -27,7 +27,6 @@ import { ClassValue } from 'clsx';
 		TranslatePipe,
 		GeoPointComponent,
 		DatePipe,
-		JsonPipe,
 		HlmCheckbox,
 		HlmDatePicker
 	],

--- a/projects/civilio/src/app/components/tabular-field/tabular-field.component.ts
+++ b/projects/civilio/src/app/components/tabular-field/tabular-field.component.ts
@@ -1,34 +1,24 @@
-import { DecimalPipe, NgClass, NgTemplateOutlet } from "@angular/common";
 import {
-  Component,
-  computed,
-  forwardRef,
-  input,
-  Signal,
-  signal,
+	Component,
+	forwardRef,
+	input,
+	Signal
 } from "@angular/core";
-import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
-import { ParsedValue, parseValue } from "@app/model/form";
+import { NG_VALUE_ACCESSOR } from "@angular/forms";
 import { Option } from "@civilio/shared";
-import { NgIcon, provideIcons } from "@ng-icons/core";
+import { provideIcons } from "@ng-icons/core";
 import {
-  lucideCheck,
-  lucideCheckCheck,
-  lucidePencil,
-  lucidePlus,
-  lucideTrash2,
-  lucideX,
+	lucideCheck,
+	lucideCheckCheck,
+	lucidePencil,
+	lucidePlus,
+	lucideTrash2,
+	lucideX,
 } from "@ng-icons/lucide";
-import { TranslatePipe } from "@ngx-translate/core";
 import { BrnSelectImports } from "@spartan-ng/brain/select";
-import { HlmButton } from "@spartan-ng/helm/button";
 import { HlmCheckboxImports } from "@spartan-ng/helm/checkbox";
-import { HlmInput } from "@spartan-ng/helm/input";
 import { HlmSelectImports } from "@spartan-ng/helm/select";
 import { HlmTableImports } from "@spartan-ng/helm/table";
-import { derivedFrom } from "ngxtension/derived-from";
-import { map, pipe } from "rxjs";
-import z from "zod";
 
 export type RowAction<T> = {
   class?: string;
@@ -95,17 +85,10 @@ export type TableDefinition<T> = {
 @Component({
   selector: "cv-tabular-field",
   imports: [
-    TranslatePipe,
     HlmTableImports,
     HlmSelectImports,
     HlmCheckboxImports,
-    DecimalPipe,
     BrnSelectImports,
-    HlmInput,
-    HlmButton,
-    NgTemplateOutlet,
-    NgIcon,
-    NgClass,
   ],
   templateUrl: "./tabular-field.component.html",
   styleUrl: "./tabular-field.component.scss",

--- a/projects/civilio/src/app/pages/forms/section-page/section.page.ts
+++ b/projects/civilio/src/app/pages/forms/section-page/section.page.ts
@@ -131,7 +131,8 @@ export class SectionPage implements AfterViewInit {
 		for (const { key } of fields) {
 			const isRelevant = rr[key];
 			const controlExists = this.form.contains(key);
-			const shouldRemove = !isRelevant && controlExists;
+			const isFieldInSection = untracked(this.sectionSchema).fields.some(f => f.key === key);
+			const shouldRemove = !isRelevant && controlExists || !isFieldInSection;
 
 			if (!shouldRemove) continue;
 			this.form.removeControl(key);

--- a/projects/electron/assets/migrations/0000_empty_johnny_blaze.sql
+++ b/projects/electron/assets/migrations/0000_empty_johnny_blaze.sql
@@ -1,0 +1,50 @@
+-- Current sql file was generated after introspecting the database
+-- If you want to run this migration please uncomment this code before executing migrations
+-- CREATE SCHEMA "civilio";
+-- --> statement-breakpoint
+-- CREATE TYPE "civilio"."form_types" AS ENUM('fosa', 'chefferie', 'csc');--> statement-breakpoint
+-- CREATE SEQUENCE "civilio"."chefferie_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 457502754 CACHE 1;--> statement-breakpoint
+-- CREATE SEQUENCE "civilio"."chefferie_index_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 324 CACHE 1;--> statement-breakpoint
+-- CREATE SEQUENCE "civilio"."chefferie_personnel_index_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 186 CACHE 1;--> statement-breakpoint
+-- CREATE SEQUENCE "civilio"."csc_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 475016321 CACHE 1;--> statement-breakpoint
+-- CREATE SEQUENCE "civilio"."csc_index_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 445 CACHE 1;--> statement-breakpoint
+-- CREATE SEQUENCE "civilio"."csc_personnel_index_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 774 CACHE 1;--> statement-breakpoint
+-- CREATE SEQUENCE "civilio"."csc_pieces_index_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 543 CACHE 1;--> statement-breakpoint
+-- CREATE SEQUENCE "civilio"."csc_statistics_index_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1463 CACHE 1;--> statement-breakpoint
+-- CREATE SEQUENCE "civilio"."csc_villages_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 2344 CACHE 1;--> statement-breakpoint
+-- CREATE SEQUENCE "civilio"."fosa_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 484119070 CACHE 1;--> statement-breakpoint
+-- CREATE SEQUENCE "civilio"."fosa_index_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 971 CACHE 1;--> statement-breakpoint
+-- CREATE SEQUENCE "civilio"."fosa_personnel_index_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1261 CACHE 1;--> statement-breakpoint
+-- CREATE TABLE "civilio"."migrations" (
+-- 	"_version" integer NOT NULL,
+-- 	"applied_at" timestamp DEFAULT now()
+-- );
+-- --> statement-breakpoint
+-- CREATE TABLE "civilio"."validation_codes" (
+-- 	"form" "civilio"."form_types" NOT NULL,
+-- 	"code" text NOT NULL,
+-- 	CONSTRAINT "validation_codes_code_key" UNIQUE("code")
+-- );
+-- --> statement-breakpoint
+-- CREATE TABLE "civilio"."choices" (
+-- 	"name" text NOT NULL,
+-- 	"label" text NOT NULL,
+-- 	"parent" text,
+-- 	"group" text NOT NULL,
+-- 	"i18n_key" text,
+-- 	"version" "civilio"."form_types" NOT NULL,
+-- 	CONSTRAINT "choices_pkey" PRIMARY KEY("name","group","version")
+-- );
+-- --> statement-breakpoint
+-- CREATE TABLE "civilio"."form_field_mappings" (
+-- 	"field" text NOT NULL,
+-- 	"i18n_key" text,
+-- 	"db_column" text NOT NULL,
+-- 	"db_table" text NOT NULL,
+-- 	"form" "civilio"."form_types" NOT NULL,
+-- 	"db_column_type" text NOT NULL,
+-- 	CONSTRAINT "field_db_column_db_table_form_pk" PRIMARY KEY("field","form")
+-- );
+-- --> statement-breakpoint
+-- CREATE VIEW "civilio"."vw_submissions" AS (SELECT _id, _index, _validation_status, validation_code, facility_name, _submission_time, form, next, prev, lower(COALESCE(_validation_status, ''::text)) = 'validation_status_approved'::text AS is_valid FROM ( SELECT df._id::double precision::integer AS _id, df._index, df._validation_status::text AS _validation_status, df.code_de_validation::text AS validation_code, df.q2_4_officename::text AS facility_name, df._submission_time::date AS _submission_time, ( SELECT 'csc'::civilio.form_types AS form_types) AS form, lead(df._index) OVER (ORDER BY df._index) AS next, lag(df._index) OVER (ORDER BY df._index) AS prev FROM csc.data df UNION SELECT df._id::double precision::integer AS _id, df._index, df._validation_status::text AS _validation_status, df.q14_02_validation_code::text AS validation_code, df.q1_12_officename::text AS facility_name, df._submission_time, ( SELECT 'fosa'::civilio.form_types AS form_types) AS form, lead(df._index) OVER (ORDER BY df._index) AS next, lag(df._index) OVER (ORDER BY df._index) AS prev FROM fosa.data df UNION SELECT df._id::double precision::integer AS _id, df._index, df._validation_status::text AS _validation_status, df.q14_02_validation_code::text AS validation_code, df.q1_12_officename::text AS facility_name, df._submission_time, ( SELECT 'chefferie'::civilio.form_types AS form_types) AS form, lead(df._index) OVER (ORDER BY df._index) AS next, lag(df._index) OVER (ORDER BY df._index) AS prev FROM chefferie.data df) result ORDER BY _submission_time DESC);
+--

--- a/projects/electron/assets/migrations/0001_whole_captain_midlands.sql
+++ b/projects/electron/assets/migrations/0001_whole_captain_midlands.sql
@@ -1,0 +1,1 @@
+CREATE VIEW "civilio"."vw_db_columns" AS (SELECT c.column_name, c.data_type, c.table_name, CAST(c.table_schema as "civilio"."form_types") FROM information_schema.columns c WHERE c.table_schema in ('fosa', 'chefferie', 'csc'));

--- a/projects/electron/assets/migrations/0002_whole_excalibur.sql
+++ b/projects/electron/assets/migrations/0002_whole_excalibur.sql
@@ -1,0 +1,2 @@
+DROP VIEW "civilio"."vw_db_columns";--> statement-breakpoint
+CREATE VIEW "civilio"."vw_db_columns" AS (SELECT c.column_name, c.data_type, c.table_name, CAST(c.table_schema as "civilio"."form_types") as form FROM information_schema.columns c WHERE c.table_schema in ('fosa', 'chefferie', 'csc'));

--- a/projects/electron/assets/migrations/0003_sharp_hellfire_club.sql
+++ b/projects/electron/assets/migrations/0003_sharp_hellfire_club.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "civilio"."form_field_mappings" ADD COLUMN "alias_hash" text GENERATED ALWAYS AS (md5("civilio"."form_field_mappings"."field")) STORED;

--- a/projects/electron/assets/migrations/meta/0000_snapshot.json
+++ b/projects/electron/assets/migrations/meta/0000_snapshot.json
@@ -1,0 +1,403 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "prevId": "",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "civilio.migrations": {
+      "name": "migrations",
+      "schema": "civilio",
+      "columns": {
+        "_version": {
+          "name": "_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "civilio.validation_codes": {
+      "name": "validation_codes",
+      "schema": "civilio",
+      "columns": {
+        "form": {
+          "name": "form",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "validation_codes_code_key": {
+          "columns": [
+            "code"
+          ],
+          "nullsNotDistinct": false,
+          "name": "validation_codes_code_key"
+        }
+      },
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "civilio.choices": {
+      "name": "choices",
+      "schema": "civilio",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent": {
+          "name": "parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "i18n_key": {
+          "name": "i18n_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "choices_pkey": {
+          "name": "choices_pkey",
+          "columns": [
+            "name",
+            "group",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "civilio.form_field_mappings": {
+      "name": "form_field_mappings",
+      "schema": "civilio",
+      "columns": {
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "i18n_key": {
+          "name": "i18n_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "db_column": {
+          "name": "db_column",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_table": {
+          "name": "db_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form": {
+          "name": "form",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_column_type": {
+          "name": "db_column_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "field_db_column_db_table_form_pk": {
+          "name": "field_db_column_db_table_form_pk",
+          "columns": [
+            "field",
+            "form"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "civilio.form_types": {
+      "name": "form_types",
+      "values": [
+        "fosa",
+        "chefferie",
+        "csc"
+      ],
+      "schema": "civilio"
+    }
+  },
+  "schemas": {
+    "civilio": "civilio"
+  },
+  "sequences": {
+    "civilio.chefferie_id_seq": {
+      "name": "chefferie_id_seq",
+      "schema": "civilio",
+      "startWith": "457502754",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "increment": "1",
+      "cycle": false,
+      "cache": "1"
+    },
+    "civilio.chefferie_index_seq": {
+      "name": "chefferie_index_seq",
+      "schema": "civilio",
+      "startWith": "324",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "increment": "1",
+      "cycle": false,
+      "cache": "1"
+    },
+    "civilio.chefferie_personnel_index_seq": {
+      "name": "chefferie_personnel_index_seq",
+      "schema": "civilio",
+      "startWith": "186",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "increment": "1",
+      "cycle": false,
+      "cache": "1"
+    },
+    "civilio.csc_id_seq": {
+      "name": "csc_id_seq",
+      "schema": "civilio",
+      "startWith": "475016321",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "increment": "1",
+      "cycle": false,
+      "cache": "1"
+    },
+    "civilio.csc_index_seq": {
+      "name": "csc_index_seq",
+      "schema": "civilio",
+      "startWith": "445",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "increment": "1",
+      "cycle": false,
+      "cache": "1"
+    },
+    "civilio.csc_personnel_index_seq": {
+      "name": "csc_personnel_index_seq",
+      "schema": "civilio",
+      "startWith": "774",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "increment": "1",
+      "cycle": false,
+      "cache": "1"
+    },
+    "civilio.csc_pieces_index_seq": {
+      "name": "csc_pieces_index_seq",
+      "schema": "civilio",
+      "startWith": "543",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "increment": "1",
+      "cycle": false,
+      "cache": "1"
+    },
+    "civilio.csc_statistics_index_seq": {
+      "name": "csc_statistics_index_seq",
+      "schema": "civilio",
+      "startWith": "1463",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "increment": "1",
+      "cycle": false,
+      "cache": "1"
+    },
+    "civilio.csc_villages_seq": {
+      "name": "csc_villages_seq",
+      "schema": "civilio",
+      "startWith": "2344",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "increment": "1",
+      "cycle": false,
+      "cache": "1"
+    },
+    "civilio.fosa_id_seq": {
+      "name": "fosa_id_seq",
+      "schema": "civilio",
+      "startWith": "484119070",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "increment": "1",
+      "cycle": false,
+      "cache": "1"
+    },
+    "civilio.fosa_index_seq": {
+      "name": "fosa_index_seq",
+      "schema": "civilio",
+      "startWith": "971",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "increment": "1",
+      "cycle": false,
+      "cache": "1"
+    },
+    "civilio.fosa_personnel_index_seq": {
+      "name": "fosa_personnel_index_seq",
+      "schema": "civilio",
+      "startWith": "1261",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "increment": "1",
+      "cycle": false,
+      "cache": "1"
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {
+    "civilio.vw_submissions": {
+      "name": "vw_submissions",
+      "schema": "civilio",
+      "columns": {
+        "_id": {
+          "name": "_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_index": {
+          "name": "_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_validation_status": {
+          "name": "_validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validation_code": {
+          "name": "validation_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facility_name": {
+          "name": "facility_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_submission_time": {
+          "name": "_submission_time",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form": {
+          "name": "form",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next": {
+          "name": "next",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev": {
+          "name": "prev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_valid": {
+          "name": "is_valid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "isExisting": false,
+      "definition": "SELECT _id, _index, _validation_status, validation_code, facility_name, _submission_time, form, next, prev, lower(COALESCE(_validation_status, ''::text)) = 'validation_status_approved'::text AS is_valid FROM ( SELECT df._id::double precision::integer AS _id, df._index, df._validation_status::text AS _validation_status, df.code_de_validation::text AS validation_code, df.q2_4_officename::text AS facility_name, df._submission_time::date AS _submission_time, ( SELECT 'csc'::civilio.form_types AS form_types) AS form, lead(df._index) OVER (ORDER BY df._index) AS next, lag(df._index) OVER (ORDER BY df._index) AS prev FROM csc.data df UNION SELECT df._id::double precision::integer AS _id, df._index, df._validation_status::text AS _validation_status, df.q14_02_validation_code::text AS validation_code, df.q1_12_officename::text AS facility_name, df._submission_time, ( SELECT 'fosa'::civilio.form_types AS form_types) AS form, lead(df._index) OVER (ORDER BY df._index) AS next, lag(df._index) OVER (ORDER BY df._index) AS prev FROM fosa.data df UNION SELECT df._id::double precision::integer AS _id, df._index, df._validation_status::text AS _validation_status, df.q14_02_validation_code::text AS validation_code, df.q1_12_officename::text AS facility_name, df._submission_time, ( SELECT 'chefferie'::civilio.form_types AS form_types) AS form, lead(df._index) OVER (ORDER BY df._index) AS next, lag(df._index) OVER (ORDER BY df._index) AS prev FROM chefferie.data df) result ORDER BY _submission_time DESC",
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {}
+  }
+}

--- a/projects/electron/assets/migrations/meta/0001_snapshot.json
+++ b/projects/electron/assets/migrations/meta/0001_snapshot.json
@@ -1,0 +1,434 @@
+{
+  "id": "bba474b7-150c-47b6-9bb9-e88de6de9843",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "civilio.choices": {
+      "name": "choices",
+      "schema": "civilio",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent": {
+          "name": "parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "i18n_key": {
+          "name": "i18n_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "choices_pkey": {
+          "name": "choices_pkey",
+          "columns": [
+            "name",
+            "group",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "civilio.form_field_mappings": {
+      "name": "form_field_mappings",
+      "schema": "civilio",
+      "columns": {
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "i18n_key": {
+          "name": "i18n_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "db_column": {
+          "name": "db_column",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_table": {
+          "name": "db_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form": {
+          "name": "form",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_column_type": {
+          "name": "db_column_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "field_db_column_db_table_form_pk": {
+          "name": "field_db_column_db_table_form_pk",
+          "columns": [
+            "field",
+            "form"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "civilio.migrations": {
+      "name": "migrations",
+      "schema": "civilio",
+      "columns": {
+        "_version": {
+          "name": "_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "civilio.validation_codes": {
+      "name": "validation_codes",
+      "schema": "civilio",
+      "columns": {
+        "form": {
+          "name": "form",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "validation_codes_code_key": {
+          "name": "validation_codes_code_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "civilio.form_types": {
+      "name": "form_types",
+      "schema": "civilio",
+      "values": [
+        "fosa",
+        "chefferie",
+        "csc"
+      ]
+    }
+  },
+  "schemas": {
+    "civilio": "civilio"
+  },
+  "sequences": {
+    "civilio.chefferie_id_seq": {
+      "name": "chefferie_id_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "457502754",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.chefferie_index_seq": {
+      "name": "chefferie_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "324",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.chefferie_personnel_index_seq": {
+      "name": "chefferie_personnel_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "186",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.csc_id_seq": {
+      "name": "csc_id_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "475016321",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.csc_index_seq": {
+      "name": "csc_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "445",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.csc_personnel_index_seq": {
+      "name": "csc_personnel_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "774",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.csc_pieces_index_seq": {
+      "name": "csc_pieces_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "543",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.csc_statistics_index_seq": {
+      "name": "csc_statistics_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "1463",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.csc_villages_seq": {
+      "name": "csc_villages_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "2344",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.fosa_id_seq": {
+      "name": "fosa_id_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "484119070",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.fosa_index_seq": {
+      "name": "fosa_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "971",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.fosa_personnel_index_seq": {
+      "name": "fosa_personnel_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "1261",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {
+    "civilio.vw_db_columns": {
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataType": {
+          "name": "dataType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tableName": {
+          "name": "tableName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form": {
+          "name": "form",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT c.column_name, c.data_type, c.table_name, CAST(c.table_schema as \"civilio\".\"form_types\") FROM information_schema.columns c WHERE c.table_schema in ('fosa', 'chefferie', 'csc')",
+      "name": "vw_db_columns",
+      "schema": "civilio",
+      "isExisting": false,
+      "materialized": false
+    },
+    "civilio.vw_submissions": {
+      "columns": {
+        "_id": {
+          "name": "_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_index": {
+          "name": "_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_validation_status": {
+          "name": "_validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validation_code": {
+          "name": "validation_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facility_name": {
+          "name": "facility_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_submission_time": {
+          "name": "_submission_time",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form": {
+          "name": "form",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next": {
+          "name": "next",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev": {
+          "name": "prev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_valid": {
+          "name": "is_valid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT _id, _index, _validation_status, validation_code, facility_name, _submission_time, form, next, prev, lower(COALESCE(_validation_status, ''::text)) = 'validation_status_approved'::text AS is_valid FROM ( SELECT df._id::double precision::integer AS _id, df._index, df._validation_status::text AS _validation_status, df.code_de_validation::text AS validation_code, df.q2_4_officename::text AS facility_name, df._submission_time::date AS _submission_time, ( SELECT 'csc'::civilio.form_types AS form_types) AS form, lead(df._index) OVER (ORDER BY df._index) AS next, lag(df._index) OVER (ORDER BY df._index) AS prev FROM csc.data df UNION SELECT df._id::double precision::integer AS _id, df._index, df._validation_status::text AS _validation_status, df.q14_02_validation_code::text AS validation_code, df.q1_12_officename::text AS facility_name, df._submission_time, ( SELECT 'fosa'::civilio.form_types AS form_types) AS form, lead(df._index) OVER (ORDER BY df._index) AS next, lag(df._index) OVER (ORDER BY df._index) AS prev FROM fosa.data df UNION SELECT df._id::double precision::integer AS _id, df._index, df._validation_status::text AS _validation_status, df.q14_02_validation_code::text AS validation_code, df.q1_12_officename::text AS facility_name, df._submission_time, ( SELECT 'chefferie'::civilio.form_types AS form_types) AS form, lead(df._index) OVER (ORDER BY df._index) AS next, lag(df._index) OVER (ORDER BY df._index) AS prev FROM chefferie.data df) result ORDER BY _submission_time DESC",
+      "name": "vw_submissions",
+      "schema": "civilio",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/projects/electron/assets/migrations/meta/0002_snapshot.json
+++ b/projects/electron/assets/migrations/meta/0002_snapshot.json
@@ -1,0 +1,434 @@
+{
+  "id": "975084d4-5d0b-4eeb-adbc-52639f12b3b3",
+  "prevId": "bba474b7-150c-47b6-9bb9-e88de6de9843",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "civilio.choices": {
+      "name": "choices",
+      "schema": "civilio",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent": {
+          "name": "parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "i18n_key": {
+          "name": "i18n_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "choices_pkey": {
+          "name": "choices_pkey",
+          "columns": [
+            "name",
+            "group",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "civilio.form_field_mappings": {
+      "name": "form_field_mappings",
+      "schema": "civilio",
+      "columns": {
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "i18n_key": {
+          "name": "i18n_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "db_column": {
+          "name": "db_column",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_table": {
+          "name": "db_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form": {
+          "name": "form",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_column_type": {
+          "name": "db_column_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "field_db_column_db_table_form_pk": {
+          "name": "field_db_column_db_table_form_pk",
+          "columns": [
+            "field",
+            "form"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "civilio.migrations": {
+      "name": "migrations",
+      "schema": "civilio",
+      "columns": {
+        "_version": {
+          "name": "_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "civilio.validation_codes": {
+      "name": "validation_codes",
+      "schema": "civilio",
+      "columns": {
+        "form": {
+          "name": "form",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "validation_codes_code_key": {
+          "name": "validation_codes_code_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "civilio.form_types": {
+      "name": "form_types",
+      "schema": "civilio",
+      "values": [
+        "fosa",
+        "chefferie",
+        "csc"
+      ]
+    }
+  },
+  "schemas": {
+    "civilio": "civilio"
+  },
+  "sequences": {
+    "civilio.chefferie_id_seq": {
+      "name": "chefferie_id_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "457502754",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.chefferie_index_seq": {
+      "name": "chefferie_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "324",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.chefferie_personnel_index_seq": {
+      "name": "chefferie_personnel_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "186",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.csc_id_seq": {
+      "name": "csc_id_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "475016321",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.csc_index_seq": {
+      "name": "csc_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "445",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.csc_personnel_index_seq": {
+      "name": "csc_personnel_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "774",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.csc_pieces_index_seq": {
+      "name": "csc_pieces_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "543",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.csc_statistics_index_seq": {
+      "name": "csc_statistics_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "1463",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.csc_villages_seq": {
+      "name": "csc_villages_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "2344",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.fosa_id_seq": {
+      "name": "fosa_id_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "484119070",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.fosa_index_seq": {
+      "name": "fosa_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "971",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.fosa_personnel_index_seq": {
+      "name": "fosa_personnel_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "1261",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {
+    "civilio.vw_db_columns": {
+      "columns": {
+        "column_name": {
+          "name": "column_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form": {
+          "name": "form",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT c.column_name, c.data_type, c.table_name, CAST(c.table_schema as \"civilio\".\"form_types\") as form FROM information_schema.columns c WHERE c.table_schema in ('fosa', 'chefferie', 'csc')",
+      "name": "vw_db_columns",
+      "schema": "civilio",
+      "isExisting": false,
+      "materialized": false
+    },
+    "civilio.vw_submissions": {
+      "columns": {
+        "_id": {
+          "name": "_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_index": {
+          "name": "_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_validation_status": {
+          "name": "_validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validation_code": {
+          "name": "validation_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facility_name": {
+          "name": "facility_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_submission_time": {
+          "name": "_submission_time",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form": {
+          "name": "form",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next": {
+          "name": "next",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev": {
+          "name": "prev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_valid": {
+          "name": "is_valid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT _id, _index, _validation_status, validation_code, facility_name, _submission_time, form, next, prev, lower(COALESCE(_validation_status, ''::text)) = 'validation_status_approved'::text AS is_valid FROM ( SELECT df._id::double precision::integer AS _id, df._index, df._validation_status::text AS _validation_status, df.code_de_validation::text AS validation_code, df.q2_4_officename::text AS facility_name, df._submission_time::date AS _submission_time, ( SELECT 'csc'::civilio.form_types AS form_types) AS form, lead(df._index) OVER (ORDER BY df._index) AS next, lag(df._index) OVER (ORDER BY df._index) AS prev FROM csc.data df UNION SELECT df._id::double precision::integer AS _id, df._index, df._validation_status::text AS _validation_status, df.q14_02_validation_code::text AS validation_code, df.q1_12_officename::text AS facility_name, df._submission_time, ( SELECT 'fosa'::civilio.form_types AS form_types) AS form, lead(df._index) OVER (ORDER BY df._index) AS next, lag(df._index) OVER (ORDER BY df._index) AS prev FROM fosa.data df UNION SELECT df._id::double precision::integer AS _id, df._index, df._validation_status::text AS _validation_status, df.q14_02_validation_code::text AS validation_code, df.q1_12_officename::text AS facility_name, df._submission_time, ( SELECT 'chefferie'::civilio.form_types AS form_types) AS form, lead(df._index) OVER (ORDER BY df._index) AS next, lag(df._index) OVER (ORDER BY df._index) AS prev FROM chefferie.data df) result ORDER BY _submission_time DESC",
+      "name": "vw_submissions",
+      "schema": "civilio",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/projects/electron/assets/migrations/meta/0003_snapshot.json
+++ b/projects/electron/assets/migrations/meta/0003_snapshot.json
@@ -1,0 +1,444 @@
+{
+  "id": "c144d335-c34f-422b-aaef-abec5283551d",
+  "prevId": "975084d4-5d0b-4eeb-adbc-52639f12b3b3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "civilio.choices": {
+      "name": "choices",
+      "schema": "civilio",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent": {
+          "name": "parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "i18n_key": {
+          "name": "i18n_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "choices_pkey": {
+          "name": "choices_pkey",
+          "columns": [
+            "name",
+            "group",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "civilio.form_field_mappings": {
+      "name": "form_field_mappings",
+      "schema": "civilio",
+      "columns": {
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "i18n_key": {
+          "name": "i18n_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "db_column": {
+          "name": "db_column",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_table": {
+          "name": "db_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form": {
+          "name": "form",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_column_type": {
+          "name": "db_column_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_hash": {
+          "name": "alias_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "md5(\"civilio\".\"form_field_mappings\".\"field\")",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "field_db_column_db_table_form_pk": {
+          "name": "field_db_column_db_table_form_pk",
+          "columns": [
+            "field",
+            "form"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "civilio.migrations": {
+      "name": "migrations",
+      "schema": "civilio",
+      "columns": {
+        "_version": {
+          "name": "_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "civilio.validation_codes": {
+      "name": "validation_codes",
+      "schema": "civilio",
+      "columns": {
+        "form": {
+          "name": "form",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "validation_codes_code_key": {
+          "name": "validation_codes_code_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "civilio.form_types": {
+      "name": "form_types",
+      "schema": "civilio",
+      "values": [
+        "fosa",
+        "chefferie",
+        "csc"
+      ]
+    }
+  },
+  "schemas": {
+    "civilio": "civilio"
+  },
+  "sequences": {
+    "civilio.chefferie_id_seq": {
+      "name": "chefferie_id_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "457502754",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.chefferie_index_seq": {
+      "name": "chefferie_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "324",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.chefferie_personnel_index_seq": {
+      "name": "chefferie_personnel_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "186",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.csc_id_seq": {
+      "name": "csc_id_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "475016321",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.csc_index_seq": {
+      "name": "csc_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "445",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.csc_personnel_index_seq": {
+      "name": "csc_personnel_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "774",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.csc_pieces_index_seq": {
+      "name": "csc_pieces_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "543",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.csc_statistics_index_seq": {
+      "name": "csc_statistics_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "1463",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.csc_villages_seq": {
+      "name": "csc_villages_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "2344",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.fosa_id_seq": {
+      "name": "fosa_id_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "484119070",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.fosa_index_seq": {
+      "name": "fosa_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "971",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    },
+    "civilio.fosa_personnel_index_seq": {
+      "name": "fosa_personnel_index_seq",
+      "schema": "civilio",
+      "increment": "1",
+      "startWith": "1261",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {
+    "civilio.vw_db_columns": {
+      "columns": {
+        "column_name": {
+          "name": "column_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form": {
+          "name": "form",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT c.column_name, c.data_type, c.table_name, CAST(c.table_schema as \"civilio\".\"form_types\") as form FROM information_schema.columns c WHERE c.table_schema in ('fosa', 'chefferie', 'csc')",
+      "name": "vw_db_columns",
+      "schema": "civilio",
+      "isExisting": false,
+      "materialized": false
+    },
+    "civilio.vw_submissions": {
+      "columns": {
+        "_id": {
+          "name": "_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_index": {
+          "name": "_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_validation_status": {
+          "name": "_validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validation_code": {
+          "name": "validation_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facility_name": {
+          "name": "facility_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_submission_time": {
+          "name": "_submission_time",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form": {
+          "name": "form",
+          "type": "form_types",
+          "typeSchema": "civilio",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next": {
+          "name": "next",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev": {
+          "name": "prev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_valid": {
+          "name": "is_valid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT _id, _index, _validation_status, validation_code, facility_name, _submission_time, form, next, prev, lower(COALESCE(_validation_status, ''::text)) = 'validation_status_approved'::text AS is_valid FROM ( SELECT df._id::double precision::integer AS _id, df._index, df._validation_status::text AS _validation_status, df.code_de_validation::text AS validation_code, df.q2_4_officename::text AS facility_name, df._submission_time::date AS _submission_time, ( SELECT 'csc'::civilio.form_types AS form_types) AS form, lead(df._index) OVER (ORDER BY df._index) AS next, lag(df._index) OVER (ORDER BY df._index) AS prev FROM csc.data df UNION SELECT df._id::double precision::integer AS _id, df._index, df._validation_status::text AS _validation_status, df.q14_02_validation_code::text AS validation_code, df.q1_12_officename::text AS facility_name, df._submission_time, ( SELECT 'fosa'::civilio.form_types AS form_types) AS form, lead(df._index) OVER (ORDER BY df._index) AS next, lag(df._index) OVER (ORDER BY df._index) AS prev FROM fosa.data df UNION SELECT df._id::double precision::integer AS _id, df._index, df._validation_status::text AS _validation_status, df.q14_02_validation_code::text AS validation_code, df.q1_12_officename::text AS facility_name, df._submission_time, ( SELECT 'chefferie'::civilio.form_types AS form_types) AS form, lead(df._index) OVER (ORDER BY df._index) AS next, lag(df._index) OVER (ORDER BY df._index) AS prev FROM chefferie.data df) result ORDER BY _submission_time DESC",
+      "name": "vw_submissions",
+      "schema": "civilio",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/projects/electron/assets/migrations/meta/_journal.json
+++ b/projects/electron/assets/migrations/meta/_journal.json
@@ -1,0 +1,34 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1757894435455,
+      "tag": "0000_empty_johnny_blaze",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1758320046879,
+      "tag": "0001_whole_captain_midlands",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1758321796276,
+      "tag": "0002_whole_excalibur",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1762430076262,
+      "tag": "0003_sharp_hellfire_club",
+      "breakpoints": true
+    }
+  ]
+}

--- a/projects/electron/src/db/schema.ts
+++ b/projects/electron/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { pgTable, pgSchema, integer, timestamp, unique, text, primaryKey, date, boolean } from "drizzle-orm/pg-core"
-import { inArray, sql } from "drizzle-orm"
+import { inArray, SQL, sql } from "drizzle-orm"
 
 export const civilio = pgSchema("civilio");
 export const formTypes = civilio.enum("form_types", ['fosa', 'chefferie', 'csc'])
@@ -18,54 +18,55 @@ export const fosaIndexSeqInCivilio = civilio.sequence("fosa_index_seq", { startW
 export const fosaPersonnelIndexSeqInCivilio = civilio.sequence("fosa_personnel_index_seq", { startWith: "1261", increment: "1", minValue: "1", maxValue: "9223372036854775807", cache: "1", cycle: false })
 
 export const migrationsInCivilio = civilio.table("migrations", {
-  version: integer("_version").notNull(),
-  appliedAt: timestamp("applied_at", { mode: 'string' }).defaultNow(),
+	version: integer("_version").notNull(),
+	appliedAt: timestamp("applied_at", { mode: 'string' }).defaultNow(),
 });
 
 export const validationCodesInCivilio = civilio.table("validation_codes", {
-  form: formTypes().notNull(),
-  code: text().notNull(),
+	form: formTypes().notNull(),
+	code: text().notNull(),
 }, (table) => [
-  unique("validation_codes_code_key").on(table.code),
+	unique("validation_codes_code_key").on(table.code),
 ]);
 
 export const choices = civilio.table("choices", {
-  name: text().notNull(),
-  label: text().notNull(),
-  parent: text(),
-  group: text().notNull(),
-  i18NKey: text("i18n_key"),
-  version: formTypes().notNull(),
+	name: text().notNull(),
+	label: text().notNull(),
+	parent: text(),
+	group: text().notNull(),
+	i18NKey: text("i18n_key"),
+	version: formTypes().notNull(),
 }, (table) => [
-  primaryKey({ columns: [table.name, table.group, table.version], name: "choices_pkey" }),
+	primaryKey({ columns: [table.name, table.group, table.version], name: "choices_pkey" }),
 ]);
 
 export const fieldMappings = civilio.table("form_field_mappings", {
-  field: text().notNull(),
-  i18nKey: text("i18n_key"),
-  dbColumn: text("db_column").notNull(),
-  dbTable: text("db_table").notNull(),
-  form: formTypes().notNull(),
-  dbColumnType: text("db_column_type").notNull(),
+	field: text().notNull(),
+	i18nKey: text("i18n_key"),
+	dbColumn: text("db_column").notNull(),
+	dbTable: text("db_table").notNull(),
+	form: formTypes().notNull(),
+	dbColumnType: text("db_column_type").notNull(),
+	aliasHash: text("alias_hash").generatedAlwaysAs((): SQL => sql<string>`md5(${fieldMappings.field})`),
 }, (table) => [
-  primaryKey({ columns: [table.field, table.form], name: "field_db_column_db_table_form_pk" }),
+	primaryKey({ columns: [table.field, table.form], name: "field_db_column_db_table_form_pk" }),
 ]);
 export const vwFormSubmissions = civilio.view("vw_submissions", {
-  id: integer("_id"),
-  index: integer("_index"),
-  validationStatus: text("_validation_status"),
-  validationCode: text("validation_code"),
-  facilityName: text("facility_name"),
-  submissionTime: date("_submission_time"),
-  form: formTypes(),
-  next: integer(),
-  prev: integer(),
-  isValid: boolean("is_valid"),
+	id: integer("_id"),
+	index: integer("_index"),
+	validationStatus: text("_validation_status"),
+	validationCode: text("validation_code"),
+	facilityName: text("facility_name"),
+	submissionTime: date("_submission_time"),
+	form: formTypes(),
+	next: integer(),
+	prev: integer(),
+	isValid: boolean("is_valid"),
 }).as(sql`SELECT _id, _index, _validation_status, validation_code, facility_name, _submission_time, form, next, prev, lower(COALESCE(_validation_status, ''::text)) = 'validation_status_approved'::text AS is_valid FROM ( SELECT df._id::double precision::integer AS _id, df._index, df._validation_status::text AS _validation_status, df.code_de_validation::text AS validation_code, df.q2_4_officename::text AS facility_name, df._submission_time::date AS _submission_time, ( SELECT 'csc'::civilio.form_types AS form_types) AS form, lead(df._index) OVER (ORDER BY df._index) AS next, lag(df._index) OVER (ORDER BY df._index) AS prev FROM csc.data df UNION SELECT df._id::double precision::integer AS _id, df._index, df._validation_status::text AS _validation_status, df.q14_02_validation_code::text AS validation_code, df.q1_12_officename::text AS facility_name, df._submission_time, ( SELECT 'fosa'::civilio.form_types AS form_types) AS form, lead(df._index) OVER (ORDER BY df._index) AS next, lag(df._index) OVER (ORDER BY df._index) AS prev FROM fosa.data df UNION SELECT df._id::double precision::integer AS _id, df._index, df._validation_status::text AS _validation_status, df.q14_02_validation_code::text AS validation_code, df.q1_12_officename::text AS facility_name, df._submission_time, ( SELECT 'chefferie'::civilio.form_types AS form_types) AS form, lead(df._index) OVER (ORDER BY df._index) AS next, lag(df._index) OVER (ORDER BY df._index) AS prev FROM chefferie.data df) result ORDER BY _submission_time DESC`);
 
 export const vwDbColumns = civilio.view('vw_db_columns', {
-  name: text('column_name'),
-  dataType: text('data_type'),
-  tableName: text('table_name'),
-  form: formTypes('form')
+	name: text('column_name'),
+	dataType: text('data_type'),
+	tableName: text('table_name'),
+	form: formTypes('form')
 }).as(sql`SELECT c.column_name, c.data_type, c.table_name, CAST(c.table_schema as ${formTypes}) as form FROM information_schema.columns c WHERE ${inArray(sql`c.table_schema`, formTypes.enumValues)}`)


### PR DESCRIPTION
- Add cached alias column to prevent query alias trimming
- Added migration snapshot 0002_snapshot.json with definitions for tables, enums, sequences, and views in the civilio schema.
- Added migration snapshot 0003_snapshot.json with an updated definition for the form_field_mappings table, including a new alias_hash column.
- Created a journal file _journal.json to track migration entries.
- Updated schema.ts to include the new alias_hash column in the form_field_mappings table and adjusted the view definitions accordingly.
- Refactored form.ts to utilize the new alias_hash for field mappings, improving data retrieval logic.